### PR TITLE
Update platformio.ini and refactor CAN handling in main.cpp

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ framework = arduino, espidf
 lib_deps = 
     ## pierremolinaro/ACAN2517FD@^2.1.11
     https://github.com/collin80/can_common.git
-    https://github.com/FuminoriSugawara/esp32_can.git#2024.12.16-1
+    https://github.com/FuminoriSugawara/esp32_can.git#2025.02.12-2
 
 build_flags = 
     -std=gnu++11


### PR DESCRIPTION
This pull request includes several changes to the `src/main.cpp` file and an update to the `platformio.ini` file. The changes focus on commenting out unused tasks, adding new functionalities for CAN frame handling, and enhancing logging.

Changes to `src/main.cpp`:

* Commented out the `canfdReadTaskHandle` and related task notifications to clean up unused code. [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L105-R105) [[2]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L131-R131) [[3]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L483-R521) [[4]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L934-R970)
* Added a new function `loadSingleFrame` to handle single CAN FD frame reading and processing.
* Updated `motorControl` and `loadEncoderCount` functions to call `loadSingleFrame` and `loadRxQueue` for better frame handling. [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L466-R489) [[2]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L483-R521)
* Enhanced `canfdHealthCheckTask` to log target positions, actual positions, and control words in a single line for better readability.

Changes to `platformio.ini`:

* Updated the `esp32_can` library dependency to a new version.